### PR TITLE
릴리즈 :  기본기능 API 엔드포인트 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,0 @@
-
-소개 페이지 : https://discovered-burglar-4f0.notion.site/572b026ec2c244d7b51468a11d4d3a4b?pvs=4
-
-매뉴얼 및 컨벤션 : https://discovered-burglar-4f0.notion.site/786f1c772655498eb6e688106cf006a1?v=3b861bd5598e47169d32286af204ae8f&pvs=4
-
-Jira 링크 : https://bitsidepjt.atlassian.net/jira/software/projects/BOP/boards/1

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,10 @@ dependencies {
     // GraphQL
     implementation 'org.springframework.boot:spring-boot-starter-graphql'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
+    testImplementation 'org.mockito:mockito-core:5.5.0'
+    testImplementation 'org.mockito:mockito-junit-jupiter:5.5.0'
 
     // MySQL
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ repositories {
 dependencies {
     // GraphQL
     implementation 'org.springframework.boot:spring-boot-starter-graphql'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 
     // MySQL
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/whitesacn/population/controller/RegionController.java
+++ b/src/main/java/whitesacn/population/controller/RegionController.java
@@ -1,0 +1,38 @@
+package whitesacn.population.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import whitesacn.population.dto.MonthlyStatsResponseDto;
+import whitesacn.population.dto.PopulationStatsResponseDto;
+import whitesacn.population.dto.RegionRequestDto;
+import whitesacn.population.dto.RegionResponseDto;
+import whitesacn.population.service.RegionService;
+
+@RestController
+@RequiredArgsConstructor
+@Log4j2
+@RequestMapping("/api/regions")
+public class RegionController {
+
+	private final RegionService regionService;
+
+	@PostMapping
+	public RegionResponseDto createRegion(@RequestBody RegionRequestDto request) {
+		return regionService.saveRegionData(request);
+	}
+
+	@GetMapping("/stats")
+	public PopulationStatsResponseDto getPopulationStats(@RequestParam String name, @RequestParam LocalDate date) {
+		return regionService.getPopulationStats(name, date);
+	}
+
+	@GetMapping("/monthly-stats")
+	public MonthlyStatsResponseDto getMonthlyStats(@RequestParam String name, @RequestParam int year, @RequestParam int month) {
+		return regionService.getMonthlyStats(name, year, month);
+	}
+}

--- a/src/main/java/whitesacn/population/controller/RegionController.java
+++ b/src/main/java/whitesacn/population/controller/RegionController.java
@@ -1,5 +1,11 @@
 package whitesacn.population.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -13,26 +19,62 @@ import whitesacn.population.dto.RegionRequestDto;
 import whitesacn.population.dto.RegionResponseDto;
 import whitesacn.population.service.RegionService;
 
+//NOTE: http://localhost:8080/swagger-ui/index.html
 @RestController
 @RequiredArgsConstructor
 @Log4j2
 @RequestMapping("/api/regions")
 public class RegionController {
 
-	private final RegionService regionService;
+    private final RegionService regionService;
 
-	@PostMapping
-	public RegionResponseDto createRegion(@RequestBody RegionRequestDto request) {
-		return regionService.saveRegionData(request);
-	}
+    //NOTE: {
+    //  "name": "Seoul",
+    //  "population": 10000000,
+    //  "date": "2024-11-11",
+    //  "time": "10:00:00"
+    //}
+    @Operation(summary = "지역 인구 데이터 생성", description = "지역 이름, 인구수, 날짜, 시간 정보를 입력받아 인구 데이터를 생성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "데이터 생성 성공",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = RegionResponseDto.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PostMapping
+    public RegionResponseDto createRegion(@RequestBody RegionRequestDto request) {
+        return regionService.saveRegionData(request);
+    }
 
-	@GetMapping("/stats")
-	public PopulationStatsResponseDto getPopulationStats(@RequestParam String name, @RequestParam LocalDate date) {
-		return regionService.getPopulationStats(name, date);
-	}
 
-	@GetMapping("/monthly-stats")
-	public MonthlyStatsResponseDto getMonthlyStats(@RequestParam String name, @RequestParam int year, @RequestParam int month) {
-		return regionService.getMonthlyStats(name, year, month);
-	}
+    @Operation(summary = "인구 통계 조회", description = "특정 지역과 날짜에 대한 인구 통계를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "통계 조회 성공",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = PopulationStatsResponseDto.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "404", description = "데이터 없음"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    // NOTE: http://localhost:8080/api/regions/stats?name=Seoul&date=2024-11-11
+    @GetMapping("/stats")
+    public PopulationStatsResponseDto getPopulationStats(@Parameter(description = "조회할 지역 이름") @RequestParam String name,
+                                                         @Parameter(description = "조회할 날짜") @RequestParam LocalDate date) {
+        return regionService.getPopulationStats(name, date);
+    }
+
+    @Operation(summary = "월별 인구 통계 조회", description = "특정 지역의 특정 연도와 월에 대한 월별 인구 통계를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "통계 조회 성공",
+                    content = @Content(mediaType = "application/json", schema = @Schema(implementation = MonthlyStatsResponseDto.class))),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+            @ApiResponse(responseCode = "404", description = "데이터 없음"),
+            @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    // NOTE: http://localhost:8080/api/regions/monthly-stats?name=Seoul&year=2024&month=11
+    @GetMapping("/monthly-stats")
+    public MonthlyStatsResponseDto getMonthlyStats(@Parameter(description = "조회할 지역 이름") @RequestParam String name,
+                                                   @Parameter(description = "조회할 연도") @RequestParam int year,
+                                                   @Parameter(description = "조회할 월") @RequestParam int month) {
+        return regionService.getMonthlyStats(name, year, month);
+    }
 }

--- a/src/main/java/whitesacn/population/dto/MonthlyStatsResponseDto.java
+++ b/src/main/java/whitesacn/population/dto/MonthlyStatsResponseDto.java
@@ -1,0 +1,13 @@
+package whitesacn.population.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class MonthlyStatsResponseDto {
+	private Double averagePopulation;
+	private Double monthChangeRate;
+}

--- a/src/main/java/whitesacn/population/dto/PopulationStatsResponseDto.java
+++ b/src/main/java/whitesacn/population/dto/PopulationStatsResponseDto.java
@@ -1,0 +1,14 @@
+package whitesacn.population.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PopulationStatsResponseDto {
+	private Integer currentPopulation;
+	private Double oneHourChangeRate;
+	private Double threeHourChangeRate;
+}

--- a/src/main/java/whitesacn/population/dto/RegionRequestDto.java
+++ b/src/main/java/whitesacn/population/dto/RegionRequestDto.java
@@ -1,0 +1,18 @@
+package whitesacn.population.dto;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class RegionRequestDto {
+	private String name;
+	private Integer population;
+	private LocalDate date;
+	private LocalTime time;
+}

--- a/src/main/java/whitesacn/population/dto/RegionResponseDto.java
+++ b/src/main/java/whitesacn/population/dto/RegionResponseDto.java
@@ -1,0 +1,20 @@
+package whitesacn.population.dto;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+
+@AllArgsConstructor
+@NoArgsConstructor
+public class RegionResponseDto {
+	private Long id;
+	private String name;
+	private Integer population;
+	private LocalDate date;
+	private LocalTime time;
+}

--- a/src/main/java/whitesacn/population/dto/RegionResponseDto.java
+++ b/src/main/java/whitesacn/population/dto/RegionResponseDto.java
@@ -3,6 +3,7 @@ package whitesacn.population.dto;
 import java.time.LocalDate;
 import java.time.LocalTime;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,5 +17,6 @@ public class RegionResponseDto {
 	private String name;
 	private Integer population;
 	private LocalDate date;
+	@JsonFormat(pattern = "HH:mm:ss")
 	private LocalTime time;
 }

--- a/src/main/java/whitesacn/population/entity/Region.java
+++ b/src/main/java/whitesacn/population/entity/Region.java
@@ -1,0 +1,54 @@
+package whitesacn.population.entity;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import whitesacn.population.dto.MonthlyStatsResponseDto;
+import whitesacn.population.dto.PopulationStatsResponseDto;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Region {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	private String name;
+	private Integer population;
+	private LocalDate date;
+	private LocalTime time;
+
+	public Region(String name, Integer population, LocalDate date, LocalTime time) {
+		this.name = name;
+		this.population = population;
+		this.date = date;
+		this.time = time;
+	}
+
+	// 인구 증감률 계산
+	public double calculateChangeRate(Integer previousPopulation) {
+		return previousPopulation == 0 ? 0 : ((double) (population - previousPopulation) / previousPopulation) * 100;
+	}
+
+	// PopulationStatsResponseDto 변환 메서드
+	public PopulationStatsResponseDto toPopulationStatsResponseDto(int oneHourBefore, int threeHoursBefore) {
+		return new PopulationStatsResponseDto(
+			population,
+			calculateChangeRate(oneHourBefore),
+			calculateChangeRate(threeHoursBefore)
+		);
+	}
+
+	// MonthlyStatsResponseDto 변환 메서드
+	public static MonthlyStatsResponseDto toMonthlyStatsResponseDto(double averagePopulation, double changeRate) {
+		return new MonthlyStatsResponseDto(averagePopulation, changeRate);
+	}
+}

--- a/src/main/java/whitesacn/population/repository/RegionRepository.java
+++ b/src/main/java/whitesacn/population/repository/RegionRepository.java
@@ -1,0 +1,15 @@
+package whitesacn.population.repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import whitesacn.population.entity.Region;
+
+@Repository
+public interface RegionRepository extends JpaRepository<Region, Long> {
+	List<Region> findByNameAndDate(String name, LocalDate date);
+	List<Region> findByNameAndDateBetween(String name, LocalDate startDate, LocalDate endDate);
+}

--- a/src/main/java/whitesacn/population/service/RegionService.java
+++ b/src/main/java/whitesacn/population/service/RegionService.java
@@ -1,0 +1,71 @@
+package whitesacn.population.service;
+
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import whitesacn.population.entity.Region;
+import whitesacn.population.dto.MonthlyStatsResponseDto;
+import whitesacn.population.dto.PopulationStatsResponseDto;
+import whitesacn.population.dto.RegionRequestDto;
+import whitesacn.population.dto.RegionResponseDto;
+import whitesacn.population.repository.RegionRepository;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class RegionService {
+
+	private final RegionRepository regionRepository;
+
+	public RegionResponseDto saveRegionData(RegionRequestDto request) {
+		Region region = new Region(request.getName(), request.getPopulation(), request.getDate(), request.getTime());
+		Region savedRegion = regionRepository.save(region);
+		return new RegionResponseDto(savedRegion.getId(), savedRegion.getName(), savedRegion.getPopulation(), savedRegion.getDate(), savedRegion.getTime());
+	}
+
+	public PopulationStatsResponseDto getPopulationStats(String name, LocalDate date) {
+		List<Region> regions = regionRepository.findByNameAndDate(name, date);
+		if (regions.isEmpty()) return null;
+
+		Region latestRegion = regions.get(regions.size() - 1);
+		int oneHourBefore = getPopulationBeforeTime(name, date, 1);
+		int threeHoursBefore = getPopulationBeforeTime(name, date, 3);
+
+		return latestRegion.toPopulationStatsResponseDto(oneHourBefore, threeHoursBefore);
+	}
+
+	public MonthlyStatsResponseDto getMonthlyStats(String name, int year, int month) {
+		LocalDate startDate = LocalDate.of(year, month, 1);
+		LocalDate endDate = startDate.plusMonths(1).minusDays(1);
+		List<Region> regions = regionRepository.findByNameAndDateBetween(name, startDate, endDate);
+
+		if (regions.isEmpty()) return null;
+
+		double averagePopulation = regions.stream().mapToInt(Region::getPopulation).average().orElse(0);
+		double lastMonthAverage = calculateLastMonthAverage(name, startDate);
+		double changeRate = lastMonthAverage == 0 ? 0 : ((averagePopulation - lastMonthAverage) / lastMonthAverage) * 100;
+
+		return Region.toMonthlyStatsResponseDto(averagePopulation, changeRate);
+	}
+
+	private int getPopulationBeforeTime(String name, LocalDate date, int hoursBefore) {
+		LocalTime targetTime = LocalTime.now().minusHours(hoursBefore);
+		return regionRepository.findByNameAndDate(name, date).stream()
+			.filter(r -> r.getTime().isBefore(targetTime))
+			.map(Region::getPopulation)
+			.findFirst()
+			.orElse(0);
+	}
+
+	private double calculateLastMonthAverage(String name, LocalDate startDate) {
+		LocalDate lastMonthStart = startDate.minusMonths(1);
+		LocalDate lastMonthEnd = lastMonthStart.plusMonths(1).minusDays(1);
+		List<Region> lastMonthRegions = regionRepository.findByNameAndDateBetween(name, lastMonthStart, lastMonthEnd);
+		return lastMonthRegions.stream().mapToInt(Region::getPopulation).average().orElse(0);
+	}
+}

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -5,4 +5,5 @@ spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.url=jdbc:h2:mem:bit
 spring.datasource.username=sa
 spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create
 

--- a/src/test/java/whitesacn/population/controller/RegionControllerTest.java
+++ b/src/test/java/whitesacn/population/controller/RegionControllerTest.java
@@ -1,0 +1,86 @@
+package whitesacn.population.controller;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import whitesacn.population.dto.MonthlyStatsResponseDto;
+import whitesacn.population.dto.PopulationStatsResponseDto;
+import whitesacn.population.dto.RegionRequestDto;
+import whitesacn.population.dto.RegionResponseDto;
+import whitesacn.population.service.RegionService;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+
+@WebMvcTest(RegionController.class)
+class RegionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private RegionService regionService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @DisplayName("POST /api/regions - 지역 데이터 생성")
+    @Test
+    void createRegionTest() throws Exception {
+        RegionRequestDto requestDto = new RegionRequestDto("Seoul", 10000000, LocalDate.now(), LocalTime.now());
+        RegionResponseDto responseDto = new RegionResponseDto(1L, "Seoul", 10000000, LocalDate.now(), LocalTime.now());
+
+        when(regionService.saveRegionData(any(RegionRequestDto.class))).thenReturn(responseDto);
+
+        mockMvc.perform(post("/api/regions")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(requestDto)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.name").value("Seoul"))
+                .andExpect(jsonPath("$.population").value(10000000));
+    }
+
+    @DisplayName("GET /api/regions/stats - 인구 통계 조회")
+    @Test
+    void getPopulationStatsTest() throws Exception {
+        PopulationStatsResponseDto statsResponse = new PopulationStatsResponseDto(10000000, 2.0, 1.0);
+
+        when(regionService.getPopulationStats("Seoul", LocalDate.of(2024, 11, 11))).thenReturn(statsResponse);
+
+        mockMvc.perform(get("/api/regions/stats")
+                        .param("name", "Seoul")
+                        .param("date", "2024-11-11"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.currentPopulation").value(10000000))
+                .andExpect(jsonPath("$.oneHourChangeRate").value(2.0))
+                .andExpect(jsonPath("$.threeHourChangeRate").value(1.0));
+    }
+
+    @DisplayName("GET /api/regions/monthly-stats - 월별 인구 통계 조회")
+    @Test
+    void getMonthlyStatsTest() throws Exception {
+        MonthlyStatsResponseDto monthlyStatsResponse = new MonthlyStatsResponseDto(9900000.0, 2.5);
+
+        when(regionService.getMonthlyStats("Seoul", 2024, 11)).thenReturn(monthlyStatsResponse);
+
+        mockMvc.perform(get("/api/regions/monthly-stats")
+                        .param("name", "Seoul")
+                        .param("year", "2024")
+                        .param("month", "11"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.averagePopulation").value(9900000.0))
+                .andExpect(jsonPath("$.monthChangeRate").value(2.5));
+    }
+}

--- a/src/test/java/whitesacn/population/repository/RegionRepositoryTest.java
+++ b/src/test/java/whitesacn/population/repository/RegionRepositoryTest.java
@@ -1,0 +1,60 @@
+package whitesacn.population.repository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import whitesacn.population.entity.Region;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class RegionRepositoryTest {
+
+    @Autowired
+    private RegionRepository regionRepository;
+
+    @DisplayName("findByNameAndDate - 특정 이름과 날짜로 조회")
+    @Test
+    void findByNameAndDateTest() {
+        // given
+        LocalDate date = LocalDate.of(2024, 11, 11);
+        Region region = new Region("Seoul", 10000000, date, LocalTime.of(10, 0));
+        regionRepository.save(region);
+
+        // when
+        List<Region> regions = regionRepository.findByNameAndDate("Seoul", date);
+
+        // then
+        assertThat(regions).hasSize(1);
+        assertThat(regions.get(0).getName()).isEqualTo("Seoul");
+        assertThat(regions.get(0).getPopulation()).isEqualTo(10000000);
+        assertThat(regions.get(0).getDate()).isEqualTo(date);
+        assertThat(regions.get(0).getTime()).isEqualTo(LocalTime.of(10, 0));
+    }
+
+    @DisplayName("findByNameAndDateBetween - 특정 이름과 날짜 범위로 조회")
+    @Test
+    void findByNameAndDateBetweenTest() {
+        // given
+        LocalDate startDate = LocalDate.of(2024, 11, 1);
+        LocalDate endDate = LocalDate.of(2024, 11, 30);
+
+        Region region1 = new Region("Seoul", 9900000, LocalDate.of(2024, 11, 5), LocalTime.of(10, 0));
+        Region region2 = new Region("Seoul", 10100000, LocalDate.of(2024, 11, 25), LocalTime.of(10, 0));
+
+        regionRepository.save(region1);
+        regionRepository.save(region2);
+
+        // when
+        List<Region> regions = regionRepository.findByNameAndDateBetween("Seoul", startDate, endDate);
+
+        // then
+        assertThat(regions).hasSize(2);
+        assertThat(regions).extracting("population").containsExactly(9900000, 10100000);
+    }
+}

--- a/src/test/java/whitesacn/population/service/RegionServiceTest.java
+++ b/src/test/java/whitesacn/population/service/RegionServiceTest.java
@@ -1,0 +1,74 @@
+package whitesacn.population.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import whitesacn.population.dto.MonthlyStatsResponseDto;
+import whitesacn.population.dto.PopulationStatsResponseDto;
+import whitesacn.population.dto.RegionRequestDto;
+import whitesacn.population.entity.Region;
+import whitesacn.population.repository.RegionRepository;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Optional;
+
+class RegionServiceTest {
+
+    @Mock
+    private RegionRepository regionRepository;
+
+    @InjectMocks
+    private RegionService regionService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @DisplayName("saveRegionData - 지역 데이터 저장")
+    @Test
+    void saveRegionDataTest() {
+        RegionRequestDto requestDto = new RegionRequestDto("Seoul", 10000000, LocalDate.now(), LocalTime.now());
+        Region region = new Region("Seoul", 10000000, LocalDate.now(), LocalTime.now());
+
+        when(regionRepository.save(any(Region.class))).thenReturn(region);
+
+        var savedRegion = regionService.saveRegionData(requestDto);
+
+        assertThat(savedRegion.getName()).isEqualTo("Seoul");
+        assertThat(savedRegion.getPopulation()).isEqualTo(10000000);
+    }
+
+    @DisplayName("getPopulationStats - 인구 통계 조회")
+    @Test
+    void getPopulationStatsTest() {
+        Region region = new Region("Seoul", 10000000, LocalDate.of(2024, 11, 11), LocalTime.of(10, 0));
+        when(regionRepository.findByNameAndDate("Seoul", LocalDate.of(2024, 11, 11))).thenReturn(List.of(region));
+
+        PopulationStatsResponseDto stats = regionService.getPopulationStats("Seoul", LocalDate.of(2024, 11, 11));
+
+        assertThat(stats.getCurrentPopulation()).isEqualTo(10000000);
+        assertThat(stats.getOneHourChangeRate()).isEqualTo(0);
+    }
+
+    @DisplayName("getMonthlyStats - 월별 인구 통계 조회")
+    @Test
+    void getMonthlyStatsTest() {
+        Region region1 = new Region("Seoul", 9900000, LocalDate.of(2024, 11, 1), LocalTime.of(10, 0));
+        Region region2 = new Region("Seoul", 10100000, LocalDate.of(2024, 11, 15), LocalTime.of(10, 0));
+        when(regionRepository.findByNameAndDateBetween("Seoul", LocalDate.of(2024, 11, 1), LocalDate.of(2024, 11, 30)))
+                .thenReturn(List.of(region1, region2));
+
+        MonthlyStatsResponseDto stats = regionService.getMonthlyStats("Seoul", 2024, 11);
+
+        assertThat(stats.getAveragePopulation()).isEqualTo(10000000.0);
+    }
+}


### PR DESCRIPTION
## 요구사항 리스트

**API 엔드포인트 구현**

a. 데이터 삽입 API
- [x] 엔드포인트: POST /api/regions
```
• 기능: 지역별 인구 데이터 입력
• 요청 본문: 지역 이름, 인구수, 날짜, 시간
• 응답: 저장된 데이터 정보
```

b. 인구 통계 조회 API

- [x]  엔드포인트: GET /api/regions/stats
```
• 기능: 특정 지역, 특정 날짜의 인구 통계 조회
• 요청 파라미터: 지역 이름, 날짜
• 응답:
{
"현재인구수": 숫자,
"1 시간전대비증감률": 숫자,
"3 시간전대비증감률": 숫자
}
```

 월별 통계 API

- [x] 엔드포인트: GET /api/regions/monthly-stats

```
• 기능: 특정 지역의 월별 인구 통계 조회
• 요청 파라미터: 지역 이름, 연도, 월
• 응답:
{
"월평균인구수": 숫자,
"전월대비증감률": 숫자,
}
```